### PR TITLE
server.createDatabase: Add an option to fail the request if the database already exists.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,16 @@ server.allDatabases()
   .subscribe((databases) => console.log(databases));
   // -> ["_replicator", "_users", "my-database", etc...]
 
-// Create a database.
+// Create a database. By default, this will ignore 412 errors on the assumption
+// that this means "database already exists."
 // http://docs.couchdb.org/en/latest/api/database/common.html#put--db
 server.createDatabase('test-rx-couch')
   .subscribeOnCompleted(); // fires when done
+
+// Create a database and fail if the database already exists.
+// http://docs.couchdb.org/en/latest/api/database/common.html#put--db
+server.createDatabase('test-rx-couch', {failIfExists: true})
+  .subscribeOnError(); // In this example, an error event would be sent.
 
 // Delete a database.
 // http://docs.couchdb.org/en/latest/api/database/common.html#delete--db

--- a/lib/server.js
+++ b/lib/server.js
@@ -66,12 +66,12 @@ server.prototype.allDatabases = function () {
 server.prototype.createDatabase = function (dbName, options) {
 
   if (options && typeof(options) !== 'object') {
-    throw new Error("rxCouch.server.createDatabase: options, if present, must be an object");
+    throw new Error("rxCouch.createDatabase: options, if present, must be an object");
   }
 
   const failIfExists = options && options.failIfExists;
   if (failIfExists && typeof(failIfExists) !== 'boolean') {
-    throw new Error("rxCouch.server.createDatabase: options.failIfExists, if present, must be a boolean");
+    throw new Error("rxCouch.createDatabase: options.failIfExists, if present, must be a boolean");
   }
 
   const expectedStatusValues = failIfExists ? [201] : [201, 412];

--- a/lib/server.js
+++ b/lib/server.js
@@ -56,12 +56,30 @@ server.prototype.allDatabases = function () {
 /**
  * Create a new database on the server. Return an Observable which sends only
  * an onCompleted event when the database has been created.
+ *
+ * @param dbName (String) name of database to create
+ * @param options (optional, Object) options
+ *    - failIfExists: (optional, Boolean): if true, will fail with 412 error if
+ *         database already exists
  */
 
-server.prototype.createDatabase = function (dbName) {
+server.prototype.createDatabase = function (dbName, options) {
+
+  if (options && typeof(options) !== 'object') {
+    throw new Error("rxCouch.server.createDatabase: options, if present, must be an object");
+  }
+
+  const failIfExists = options && options.failIfExists;
+  if (failIfExists && typeof(failIfExists) !== 'boolean') {
+    throw new Error("rxCouch.server.createDatabase: options.failIfExists, if present, must be a boolean");
+  }
+
+  const expectedStatusValues = failIfExists ? [201] : [201, 412];
+    // We presume 412 means "database already exists" and quietly consume that
+    // by default.
 
   return rxFetch(validateNameAndMakeUrl(this._baseUrl, dbName, 'createDatabase'), { method: 'put' })
-    .failIfStatusNotIn([201, 412])
+    .failIfStatusNotIn(expectedStatusValues)
     .filter(() => false);
 
 };

--- a/test/testServer.js
+++ b/test/testServer.js
@@ -199,6 +199,14 @@ describe("rx-couch", function () {
       expect(() => server.createDatabase('_users')).to.throw("rxCouch.createDatabase: illegal dbName");
     });
 
+    it('should throw if options is present, but not an object', function () {
+      expect(() => server.createDatabase('x', 42)).to.throw("rxCouch.createDatabase: options, if present, must be an object");
+    });
+
+    it('should throw if options.failIfExists is present, but not a boolean', function () {
+      expect(() => server.createDatabase('x', {failIfExists: "bogus"})).to.throw("rxCouch.createDatabase: options.failIfExists, if present, must be a boolean");
+    });
+
     //--------------------------------------------------------------------------
 
     it("should actually create a new database", function (done) {

--- a/test/testServer.js
+++ b/test/testServer.js
@@ -179,6 +179,10 @@ describe("rx-couch", function () {
       expectNoResults(server.createDatabase('test-rx-couch'), done);
     });
 
+    it("should succeed even if the database already exists {failIfExists: false}", function (done) {
+      expectNoResults(server.createDatabase('test-rx-couch', {failIfExists: false}), done);
+    });
+
     it("should throw if database name is missing", function () {
       expect(() => server.createDatabase()).to.throw("rxCouch.createDatabase: dbName must be a string");
     });
@@ -195,6 +199,8 @@ describe("rx-couch", function () {
       expect(() => server.createDatabase('_users')).to.throw("rxCouch.createDatabase: illegal dbName");
     });
 
+    //--------------------------------------------------------------------------
+
     it("should actually create a new database", function (done) {
 
       const dbsAfterCreate = Rx.Observable.concat(
@@ -208,6 +214,20 @@ describe("rx-couch", function () {
         });
 
     });
+
+    //--------------------------------------------------------------------------
+
+    it("should signal an error if database already exists (but only if so requested)", function (done) {
+
+      const createWithFail = server.createDatabase('test-rx-couch', {failIfExists: true});
+
+      expectOnlyError(createWithFail, done, (err) => {
+        expect(err.message).to.equal("HTTP Error 412: Precondition Failed");
+      });
+
+    });
+
+    //--------------------------------------------------------------------------
 
     it("should send an onError message if server yields unexpected result", function (done) {
 
@@ -254,6 +274,8 @@ describe("rx-couch", function () {
       expect(() => server.deleteDatabase('_users')).to.throw("rxCouch.deleteDatabase: illegal dbName");
     });
 
+    //--------------------------------------------------------------------------
+
     it("should actually delete the existing database", function (done) {
 
       const dbsAfterDelete = Rx.Observable.concat(
@@ -267,6 +289,8 @@ describe("rx-couch", function () {
         });
 
     });
+
+    //--------------------------------------------------------------------------
 
     it("should send an onError message if server yields unexpected result", function (done) {
 


### PR DESCRIPTION
Retain existing behavior of quietly ignoring 412 errors.

Should address #7.
