### PR TITLE
Require npm >= 3 and avoid the peerDependencies problem.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - stable
-  - '4.0'
+  - '5.0'
 deploy:
   provider: npm
   email: code@tangledfruit.com

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,26 +1,6 @@
 'use strict';
 
-let Rx;
-/* istanbul ignore next */
-try {
-  Rx = require('rx');
-}
-catch (err) {
-
-  /*
-    Why not add Rx as a dependency of this project? With npm 2.x, subproject
-    dependencies get installed as a separate copy. It then becomes a race condition
-    as to which copy gets patched by rx-to-async-iterator. Better to use the
-    peerDependency mechanism so you can have only one copy of RxJS in your
-    overall project.
-  */
-
-  console.log("ERROR: require 'rx' failed.");
-  console.log("Make sure your project lists rx>=4.0.7 <5 as a dependency.\n\n");
-  process.exit(1);
-
-}
-
+const Rx = require('rx');
 const rxFetch = require('rx-fetch');
 const deepEqual = require('deep-eql');
 const deepMerge = require('deepmerge');

--- a/package.json
+++ b/package.json
@@ -33,19 +33,18 @@
     "lintspaces-cli": "0.1.1",
     "mocha": "2.4.5",
     "nock": "7.2.2",
-    "rx": "4.0.8",
-    "rx-to-async-iterator": "1.1.1"
-  },
-  "peerDependencies": {
-    "rx": ">=4.0.7 <5"
+    "rx-to-async-iterator": "1.1.3"
   },
   "dependencies": {
     "deep-eql": "0.1.3",
     "deepmerge": "0.2.10",
-    "rx-fetch": "1.2.1",
+    "rx": "4.0.8",
+    "rx-fetch": "1.2.2",
     "shallow-copy": "0.0.1"
   },
   "engines": {
-    "node": ">=4.0.0"
-  }
+    "node": ">=4",
+    "npm": ">=3"
+  },
+  "engineStrict": true
 }


### PR DESCRIPTION
Use engineStrict to cause installation to fail with npm 2.x. Yes, I know engineStrict is deprecated, but that's as of npm 3.x and that's the version we need to require.

For now, we'll only verify with node 5.0 and stable. Would like to figure out how to have Travis verify node 4.0 + npm >= 3.0, but I don't see any such option at the moment.

Hopefully this fixes #27.
