### PR TITLE
Going back to range revisions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,22 +25,22 @@
   },
   "homepage": "https://github.com/tangledfruit/rx-couch#readme",
   "devDependencies": {
-    "chai": "3.5.0",
-    "co-mocha": "1.1.2",
-    "coveralls": "2.11.9",
-    "istanbul": "0.4.3",
-    "jshint": "2.9.2",
-    "lintspaces-cli": "0.1.1",
-    "mocha": "2.4.5",
-    "nock": "8.0.0",
-    "rx-to-async-iterator": "1.1.6"
+    "chai": "^3.5.0",
+    "co-mocha": "^1.1.2",
+    "coveralls": "^2.11.9",
+    "istanbul": "^0.4.3",
+    "jshint": "^2.9.2",
+    "lintspaces-cli": "^0.1.1",
+    "mocha": "^2.4.5",
+    "nock": "^8.0.0",
+    "rx-to-async-iterator": "^1.1.8"
   },
   "dependencies": {
-    "deep-eql": "0.1.3",
-    "deepmerge": "0.2.10",
+    "deep-eql": "^0.1.3",
+    "deepmerge": "^0.2.10",
     "rx": ">=4.0.7 <5",
-    "rx-fetch": "1.2.7",
-    "shallow-copy": "0.0.1"
+    "rx-fetch": "^1.2.8",
+    "shallow-copy": "^0.0.1"
   },
   "engines": {
     "node": ">=4",


### PR DESCRIPTION
Specifying dependencies via specific revisions seemed like a good idea at the time, but it results in too much signal noise.
