### PR TITLE
Improve CouchbaseLite compatibility in db.observe implementation.

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -421,9 +421,18 @@ db.prototype.observe = function (id) {
     throw new Error('rxCouch.db.observe: invalid document ID');
   }
 
+  let previousRev;
+
   return this.get(id)
-    .takeLast(0) // discard value if doc exists, we'll get it from changes
     .catch(Rx.Observable.just({_id: id, _empty: true}))
     .concat(this.changes({doc_ids: [id], feed: 'longpoll', filter: '_doc_ids', include_docs: true})
-      .map(update => update.doc));
+      .map(update => update.doc))
+    .filter(doc => {
+      if (previousRev && previousRev === doc._rev) {
+        return false;
+      } else {
+        previousRev = doc._rev;
+        return true;
+      }
+    });
 };


### PR DESCRIPTION
CBL doesn't report existing value via document-specific _changes feed, so we have to use the value from the initial get request.
